### PR TITLE
Restored  "Network" field in stakepool config

### DIFF
--- a/v1/README.md
+++ b/v1/README.md
@@ -6,3 +6,15 @@ Please read before changing anything
 
 - All fields are required for Exilibrium to work properly,
 - Addresses & slugs should be formatted without prefixing and trailing slashes
+
+### Stakepools API
+
+- Required fields are [typescript style notation]:
+  ```
+  {
+      "Host": String,
+      "APIEnabled": Boolean,
+      "Network": "mainnet" | "testnet",
+      "APIVersionsSupported": Array<1 | 2>
+  }
+  ```

--- a/v1/mainnet/stakepools.json
+++ b/v1/mainnet/stakepools.json
@@ -2,11 +2,13 @@
   {
     "Host": "https://stakepool.excc.co/",
     "APIEnabled": true,
+    "Network": "mainnet",
     "APIVersionsSupported": [1, 2]
   },
   {
     "Host": "https://stake.excc.scecf.org/",
     "APIEnabled": true,
+    "Network": "mainnet",
     "APIVersionsSupported": [1, 2]
   }
 ]

--- a/v1/testnet/stakepools.json
+++ b/v1/testnet/stakepools.json
@@ -2,6 +2,7 @@
   {
     "Host": "https://testnet-stakepool.excc.co/",
     "APIEnabled": true,
+    "Network": "testnet",
     "APIVersionsSupported": [1, 2]
   }
 ]


### PR DESCRIPTION
Lack of this field is making problem in Exilibrium, we need to restore it until it's handled in the wallet 